### PR TITLE
Add security group labels, bump alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 RUN apk add --update curl jq && rm -rf /var/cache/apk/*
 COPY apply-labels.sh /
 ENTRYPOINT [ "/apply-labels.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-A small Alpine based container that fetched AWS metadata for the instance it executes on and applies it as node labels in Kubernetes.  Ideally used by dropping into the `/etc/kubernetes/manifets` directory a pod spec like:
+A small Alpine based container that fetched AWS metadata for the instance it
+executes on and applies it as node labels in Kubernetes.  Ideally used by
+dropping into the `/etc/kubernetes/manifets` directory a pod spec like:
 
 ```
 apiVersion: v1

--- a/apply-labels.sh
+++ b/apply-labels.sh
@@ -4,7 +4,7 @@ MD="curl -s http://169.254.169.254/latest/meta-data/"
 INSTANCE_ID=`${MD}/instance-id`
 INSTANCE_TYPE=`${MD}/instance-type`
 AVAILABILITY_ZONE=`${MD}/placement/availability-zone`
-SECURITY_GROUPS=`${MD}/security-groups | tr '\n' ','`
+SECURITY_GROUPS=$(echo `${MD}/security-groups` | tr '\n' ',')
 
 # It appears it takes a while for the hostname to incorporate the node name.
 while [ "x$NODE" = "x" ] || [ "$NODE" = "null" ]; do

--- a/apply-labels.sh
+++ b/apply-labels.sh
@@ -4,6 +4,7 @@ MD="curl -s http://169.254.169.254/latest/meta-data/"
 INSTANCE_ID=`${MD}/instance-id`
 INSTANCE_TYPE=`${MD}/instance-type`
 AVAILABILITY_ZONE=`${MD}/placement/availability-zone`
+SECURITY_GROUPS=`${MD}/security-groups | tr '\n' ','`
 
 # It appears it takes a while for the hostname to incorporate the node name.
 while [ "x$NODE" = "x" ] || [ "$NODE" = "null" ]; do
@@ -33,7 +34,8 @@ curl  -s \
     "labels": {
       "aws.node.kubernetes.io/id": "${INSTANCE_ID}",
       "aws.node.kubernetes.io/type": "${INSTANCE_TYPE}",
-      "aws.node.kubernetes.io/az": "${AVAILABILITY_ZONE}"
+      "aws.node.kubernetes.io/az": "${AVAILABILITY_ZONE}",
+      "aws.node.kubernetes.io/sgs": "${SECURITY_GROUPS}"
     } 
   } 
 }

--- a/apply-labels.sh
+++ b/apply-labels.sh
@@ -10,7 +10,7 @@ SECURITY_GROUPS=$(echo `${MD}/security-groups` | tr '\n' ',')
 while [ "x$NODE" = "x" ] || [ "$NODE" = "null" ]; do
   sleep 1
   HOSTNAME=`hostname`
-  echo Hostname: $HOSTNAME
+  echo "[$(date)] Hostname: $HOSTNAME"
   NODE=`curl  -s -f \
         --cert   /etc/kubernetes/ssl/worker.pem \
         --key    /etc/kubernetes/ssl/worker-key.pem \
@@ -19,7 +19,7 @@ while [ "x$NODE" = "x" ] || [ "$NODE" = "null" ]; do
   `
 done
 
-echo Node: $NODE
+echo "[$(date)] Node: $NODE"
 
 curl  -s \
       --cert   /etc/kubernetes/ssl/worker.pem \

--- a/apply-labels.sh
+++ b/apply-labels.sh
@@ -10,7 +10,7 @@ while [ "x$NODE" = "x" ] || [ "$NODE" = "null" ]; do
   sleep 1
   HOSTNAME=`hostname`
   echo Hostname: $HOSTNAME
-  NODE=`curl  -s \
+  NODE=`curl  -s -f \
         --cert   /etc/kubernetes/ssl/worker.pem \
         --key    /etc/kubernetes/ssl/worker-key.pem \
         --cacert /etc/kubernetes/ssl/ca.pem  \


### PR DESCRIPTION
This is a bit of a mixed bag. The main addition here is to capture a node's security groups from the metadata service along with the other labels.
